### PR TITLE
Feature/image feed/UI/mvvm refactoring

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		687075B42C6526CB003942B5 /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B32C6526CB003942B5 /* FeedImageCellController.swift */; };
 		687075B72C74CAF1003942B5 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B62C74CAF1003942B5 /* FeedViewModel.swift */; };
 		687075B92C74E833003942B5 /* FeedImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B82C74E833003942B5 /* FeedImageViewModel.swift */; };
+		687075BC2C77940C003942B5 /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075BB2C77940C003942B5 /* FeedUIComposer.swift */; };
 		6878F4E92BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4E82BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift */; };
 		6878F4EC2BFDB87F0050A78D /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4EB2BFDB87F0050A78D /* FeedStoreSpy.swift */; };
 		6878F4EE2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4ED2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift */; };
@@ -151,6 +152,7 @@
 		687075B32C6526CB003942B5 /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
 		687075B62C74CAF1003942B5 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		687075B82C74E833003942B5 /* FeedImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageViewModel.swift; sourceTree = "<group>"; };
+		687075BB2C77940C003942B5 /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
 		6878F4E82BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUserCaseTests.swift; sourceTree = "<group>"; };
 		6878F4EB2BFDB87F0050A78D /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 		6878F4ED2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 		687075AC2C628063003942B5 /* Feed UI */ = {
 			isa = PBXGroup;
 			children = (
+				687075BA2C7793C3003942B5 /* Composers */,
 				687075B52C74CAD5003942B5 /* Models */,
 				6870759F2C627928003942B5 /* Controllers */,
 				687075A02C627932003942B5 /* Views */,
@@ -355,6 +358,14 @@
 				687075B82C74E833003942B5 /* FeedImageViewModel.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		687075BA2C7793C3003942B5 /* Composers */ = {
+			isa = PBXGroup;
+			children = (
+				687075BB2C77940C003942B5 /* FeedUIComposer.swift */,
+			);
+			path = Composers;
 			sourceTree = "<group>";
 		};
 		6878F4EA2BFDB8540050A78D /* Helpers */ = {
@@ -779,6 +790,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				687075B72C74CAF1003942B5 /* FeedViewModel.swift in Sources */,
+				687075BC2C77940C003942B5 /* FeedUIComposer.swift in Sources */,
 				687075B02C6283AC003942B5 /* FeedImageDataLoader.swift in Sources */,
 				687075B22C651D72003942B5 /* FeedRefreshViewController.swift in Sources */,
 				687075942C5933EA003942B5 /* UIView+Shimmering.swift in Sources */,

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		687075B22C651D72003942B5 /* FeedRefreshViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B12C651D72003942B5 /* FeedRefreshViewController.swift */; };
 		687075B42C6526CB003942B5 /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B32C6526CB003942B5 /* FeedImageCellController.swift */; };
 		687075B72C74CAF1003942B5 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B62C74CAF1003942B5 /* FeedViewModel.swift */; };
+		687075B92C74E833003942B5 /* FeedImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B82C74E833003942B5 /* FeedImageViewModel.swift */; };
 		6878F4E92BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4E82BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift */; };
 		6878F4EC2BFDB87F0050A78D /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4EB2BFDB87F0050A78D /* FeedStoreSpy.swift */; };
 		6878F4EE2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4ED2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift */; };
@@ -149,6 +150,7 @@
 		687075B12C651D72003942B5 /* FeedRefreshViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRefreshViewController.swift; sourceTree = "<group>"; };
 		687075B32C6526CB003942B5 /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
 		687075B62C74CAF1003942B5 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
+		687075B82C74E833003942B5 /* FeedImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageViewModel.swift; sourceTree = "<group>"; };
 		6878F4E82BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUserCaseTests.swift; sourceTree = "<group>"; };
 		6878F4EB2BFDB87F0050A78D /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 		6878F4ED2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 			isa = PBXGroup;
 			children = (
 				687075B62C74CAF1003942B5 /* FeedViewModel.swift */,
+				687075B82C74E833003942B5 /* FeedImageViewModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -781,6 +784,7 @@
 				687075942C5933EA003942B5 /* UIView+Shimmering.swift in Sources */,
 				687075922C5005D6003942B5 /* FeedImageCell.swift in Sources */,
 				687075902C4EA5BA003942B5 /* FeedViewController.swift in Sources */,
+				687075B92C74E833003942B5 /* FeedImageViewModel.swift in Sources */,
 				687075B42C6526CB003942B5 /* FeedImageCellController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		687075B02C6283AC003942B5 /* FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075AF2C6283AC003942B5 /* FeedImageDataLoader.swift */; };
 		687075B22C651D72003942B5 /* FeedRefreshViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B12C651D72003942B5 /* FeedRefreshViewController.swift */; };
 		687075B42C6526CB003942B5 /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B32C6526CB003942B5 /* FeedImageCellController.swift */; };
+		687075B72C74CAF1003942B5 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687075B62C74CAF1003942B5 /* FeedViewModel.swift */; };
 		6878F4E92BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4E82BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift */; };
 		6878F4EC2BFDB87F0050A78D /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4EB2BFDB87F0050A78D /* FeedStoreSpy.swift */; };
 		6878F4EE2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6878F4ED2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift */; };
@@ -147,6 +148,7 @@
 		687075AF2C6283AC003942B5 /* FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoader.swift; sourceTree = "<group>"; };
 		687075B12C651D72003942B5 /* FeedRefreshViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRefreshViewController.swift; sourceTree = "<group>"; };
 		687075B32C6526CB003942B5 /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
+		687075B62C74CAF1003942B5 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		6878F4E82BFDB75D0050A78D /* LoadFeedFromCacheUserCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUserCaseTests.swift; sourceTree = "<group>"; };
 		6878F4EB2BFDB87F0050A78D /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 		6878F4ED2BFEE1A50050A78D /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 		687075AC2C628063003942B5 /* Feed UI */ = {
 			isa = PBXGroup;
 			children = (
+				687075B52C74CAD5003942B5 /* Models */,
 				6870759F2C627928003942B5 /* Controllers */,
 				687075A02C627932003942B5 /* Views */,
 			);
@@ -341,6 +344,14 @@
 				687075AF2C6283AC003942B5 /* FeedImageDataLoader.swift */,
 			);
 			path = "Feed Image Loader";
+			sourceTree = "<group>";
+		};
+		687075B52C74CAD5003942B5 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				687075B62C74CAF1003942B5 /* FeedViewModel.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		6878F4EA2BFDB8540050A78D /* Helpers */ = {
@@ -764,6 +775,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				687075B72C74CAF1003942B5 /* FeedViewModel.swift in Sources */,
 				687075B02C6283AC003942B5 /* FeedImageDataLoader.swift in Sources */,
 				687075B22C651D72003942B5 /* FeedRefreshViewController.swift in Sources */,
 				687075942C5933EA003942B5 /* UIView+Shimmering.swift in Sources */,

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -1,0 +1,30 @@
+//
+//  FeedUIComposer.swift
+//  EssentialFeediOS
+//
+//  Created by nicaho on 2024/8/22.
+//
+
+import UIKit
+import EssentialFeed
+
+public final class FeedUIComposer {
+    private init() {}
+    
+    public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
+        let feedViewModel = FeedViewModel(feedLoader: feedLoader)
+        let refreshController = FeedRefreshViewController(viewModel: feedViewModel)
+        let feedController = FeedViewController(refreshController: refreshController)
+        feedViewModel.onFeedLoad = adaptFeedToCellControllers(forwardingTo: feedController, loader: imageLoader)
+        
+        return feedController
+    }
+    
+    private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
+        return { [weak controller] feed in
+            controller?.tableModel = feed.map { model in
+                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader, imageTransformer: UIImage.init))
+            }
+        }
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 final class FeedImageCellController {
-    private let viewModel: FeedImageViewModel
+    private let viewModel: FeedImageViewModel<UIImage>
     
-    init(viewModel: FeedImageViewModel) {
+    init(viewModel: FeedImageViewModel<UIImage>) {
         self.viewModel = viewModel
     }
     

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -6,50 +6,46 @@
 //
 
 import UIKit
-import EssentialFeed
 
 final class FeedImageCellController {
-    private var task: FeedImageDataLoaderTask?
-    private let model: FeedImage
-    private let imageLoader: FeedImageDataLoader
+    private let viewModel: FeedImageViewModel
     
-    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
-        self.model = model
-        self.imageLoader = imageLoader
+    init(viewModel: FeedImageViewModel) {
+        self.viewModel = viewModel
     }
     
     func view() -> UITableViewCell {
-        let cell = FeedImageCell()
-        cell.locationContainer.isHidden = (model.location == nil)
-        cell.locationLabel.text = model.location
-        cell.descriptionLabel.text = model.description
-        cell.feedImageView.image = nil
-        cell.feedImageRetryButton.isHidden = true
-        cell.feedImageContainer.startShimmering()
-        
-        let loadImage = { [weak self, weak cell] in
-            guard let self = self else { return }
-            
-            self.task = imageLoader.loadImageData(from: model.url) { [weak cell] result in
-                let data = try? result.get()
-                let image = data.map(UIImage.init) ?? nil
-                cell?.feedImageView.image = image
-                cell?.feedImageRetryButton.isHidden = (image != nil)
-                cell?.feedImageContainer.stopShimmering()
-            }
-        }
-        
-        cell.onRetry = loadImage
-        loadImage()
-        
+        let cell = binded(FeedImageCell())
+        viewModel.loadImageData()
         return cell
     }
     
     func preload() {
-        task = imageLoader.loadImageData(from: model.url, completion: { _ in })
+        viewModel.loadImageData()
     }
     
     func cancelLoad() {
-        task?.cancel()
+        viewModel.cancelImageDataLoad()
+    }
+    
+    private func binded(_ cell: FeedImageCell) -> FeedImageCell {
+        let cell = FeedImageCell()
+        cell.locationContainer.isHidden = !viewModel.hasLocation
+        cell.locationLabel.text = viewModel.location
+        cell.descriptionLabel.text = viewModel.description
+        cell.onRetry = viewModel.loadImageData
+        
+        viewModel.onImageLoad = { [weak cell] image in
+            cell?.feedImageView.image = image
+        }
+        
+        viewModel.onImageLoadingStateChange = { [weak cell] isLoading in
+            cell?.feedImageContainer.isShimmering = isLoading
+        }
+        
+        viewModel.onShouldRetryImageLoadStateChange = { [weak cell] shouldRetry in
+            cell?.feedImageRetryButton.isHidden = !shouldRetry
+        }
+        return cell
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
@@ -6,30 +6,29 @@
 //
 
 import UIKit
-import EssentialFeed
 
-public class FeedRefreshViewController: NSObject {
-    public lazy var view: UIRefreshControl = {
-        let view = UIRefreshControl()
-        view.addTarget(self, action: #selector(refresh), for: .valueChanged)
-        return view
-    }()
+final public class FeedRefreshViewController: NSObject {
+    public lazy var view: UIRefreshControl = binded(UIRefreshControl())
     
-    private let feedLoader: FeedLoader
+    private let viewModel: FeedViewModel
     
-    public init(feedLoader: FeedLoader) {
-        self.feedLoader = feedLoader
+    public init(viewModel: FeedViewModel) {
+        self.viewModel = viewModel
     }
     
-    var onRefresh: (([FeedImage]) -> Void)?
-    
     @objc func refresh() {
-        view.beginRefreshing()
-        feedLoader.load{ [weak self] result in
-            if let feed = try? result.get() {
-                self?.onRefresh?(feed)
+        viewModel.loadFeed()
+    }
+    
+    private func binded(_ view: UIRefreshControl) -> UIRefreshControl {
+        viewModel.onChange = { [weak self] viewModel in
+            if viewModel.isLoading {
+                self?.view.beginRefreshing()
+            } else {
+                self?.view.endRefreshing()
             }
-            self?.view.endRefreshing()
         }
+        view.addTarget(self, action: #selector(refresh), for: .valueChanged)
+        return view
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
@@ -21,8 +21,8 @@ final public class FeedRefreshViewController: NSObject {
     }
     
     private func binded(_ view: UIRefreshControl) -> UIRefreshControl {
-        viewModel.onChange = { [weak self] viewModel in
-            if viewModel.isLoading {
+        viewModel.onLoadingStateChange = { [weak self] isLoading in
+            if isLoading {
                 self?.view.beginRefreshing()
             } else {
                 self?.view.endRefreshing()

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ public final class FeedUIComposor {
     private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
         return { [weak controller] feed in
             controller?.tableModel = feed.map { model in
-                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader))
+                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader, imageTransformer: UIImage.init))
             }
         }
     }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ public final class FeedUIComposor {
     private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
         return { [weak controller] feed in
             controller?.tableModel = feed.map { model in
-                FeedImageCellController(model: model, imageLoader: loader)
+                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader))
             }
         }
     }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -12,9 +12,10 @@ public final class FeedUIComposor {
     private init() {}
     
     public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
-        let refreshController = FeedRefreshViewController(feedLoader: feedLoader)
+        let feedViewModel = FeedViewModel(feedLoader: feedLoader)
+        let refreshController = FeedRefreshViewController(viewModel: feedViewModel)
         let feedController = FeedViewController(refreshController: refreshController)
-        refreshController.onRefresh = adaptFeedToCellControllers(forwardingTo: feedController, loader: imageLoader)
+        feedViewModel.onFeedLoad = adaptFeedToCellControllers(forwardingTo: feedController, loader: imageLoader)
         
         return feedController
     }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -6,28 +6,6 @@
 //
 
 import UIKit
-import EssentialFeed
-
-public final class FeedUIComposor {
-    private init() {}
-    
-    public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
-        let feedViewModel = FeedViewModel(feedLoader: feedLoader)
-        let refreshController = FeedRefreshViewController(viewModel: feedViewModel)
-        let feedController = FeedViewController(refreshController: refreshController)
-        feedViewModel.onFeedLoad = adaptFeedToCellControllers(forwardingTo: feedController, loader: imageLoader)
-        
-        return feedController
-    }
-    
-    private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
-        return { [weak controller] feed in
-            controller?.tableModel = feed.map { model in
-                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader, imageTransformer: UIImage.init))
-            }
-        }
-    }
-}
 
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching {
     public var refreshController: FeedRefreshViewController?

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  FeedImageViewModel.swift
+//  EssentialFeediOS
+//
+//  Created by nicaho on 2024/8/20.
+//
+
+import Foundation
+import EssentialFeed
+import UIKit
+
+final class FeedImageViewModel {
+    typealias Observer<T> = (T) -> Void
+    
+    private var task: FeedImageDataLoaderTask?
+    private let model: FeedImage
+    private let imageLoader: FeedImageDataLoader
+    
+    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+        self.model = model
+        self.imageLoader = imageLoader
+    }
+    
+    var hasLocation: Bool {
+        model.location != nil
+    }
+    
+    var location: String? {
+        model.location
+    }
+    
+    var description: String? {
+        model.description
+    }
+    
+    var onImageLoad: Observer<UIImage>?
+    var onImageLoadingStateChange: Observer<Bool>?
+    var onShouldRetryImageLoadStateChange: Observer<Bool>?
+    
+    func loadImageData() {
+        onImageLoadingStateChange?(true)
+        onShouldRetryImageLoadStateChange?(false)
+        task = imageLoader.loadImageData(from: model.url, completion: { [weak self] result in
+            self?.handle(result)
+        })
+    }
+    
+    private func handle(_ result: FeedImageDataLoader.Result) {
+        if let image = (try? result.get()).flatMap(UIImage.init) {
+            onImageLoad?(image)
+        } else {
+            onShouldRetryImageLoadStateChange?(true)
+        }
+        onImageLoadingStateChange?(false)
+    }
+    
+    func cancelImageDataLoad() {
+        task?.cancel()
+        task = nil
+    }
+}
+

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
@@ -7,18 +7,19 @@
 
 import Foundation
 import EssentialFeed
-import UIKit
 
-final class FeedImageViewModel {
+final class FeedImageViewModel<Image> {
     typealias Observer<T> = (T) -> Void
     
     private var task: FeedImageDataLoaderTask?
     private let model: FeedImage
     private let imageLoader: FeedImageDataLoader
+    private let imageTransformer: (Data) -> Image?
     
-    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+    init(model: FeedImage, imageLoader: FeedImageDataLoader, imageTransformer: @escaping (Data) -> Image?) {
         self.model = model
         self.imageLoader = imageLoader
+        self.imageTransformer = imageTransformer
     }
     
     var hasLocation: Bool {
@@ -33,7 +34,7 @@ final class FeedImageViewModel {
         model.description
     }
     
-    var onImageLoad: Observer<UIImage>?
+    var onImageLoad: Observer<Image>?
     var onImageLoadingStateChange: Observer<Bool>?
     var onShouldRetryImageLoadStateChange: Observer<Bool>?
     
@@ -46,7 +47,7 @@ final class FeedImageViewModel {
     }
     
     private func handle(_ result: FeedImageDataLoader.Result) {
-        if let image = (try? result.get()).flatMap(UIImage.init) {
+        if let image = (try? result.get()).flatMap(imageTransformer) {
             onImageLoad?(image)
         } else {
             onShouldRetryImageLoadStateChange?(true)

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
@@ -9,28 +9,24 @@ import Foundation
 import EssentialFeed
 
 final public class FeedViewModel {
+    typealias Observer<T> = (T) -> Void
+    
     private let feedLoader: FeedLoader
     
     public init(feedLoader: FeedLoader) {
         self.feedLoader = feedLoader
     }
     
-    var onChange: ((FeedViewModel) -> Void)?
-    var onFeedLoad: (([FeedImage]) -> Void)?
-    
-    private(set) var isLoading: Bool = false {
-        didSet {
-            onChange?(self)
-        }
-    }
+    var onLoadingStateChange: Observer<Bool>?
+    var onFeedLoad: Observer<[FeedImage]>?
     
     func loadFeed() {
-        isLoading = true
+        onLoadingStateChange?(true)
         feedLoader.load{ [weak self] result in
             if let feed = try? result.get() {
                 self?.onFeedLoad?(feed)
             }
-            self?.isLoading = false
+            self?.onLoadingStateChange?(false)
         }
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  FeedViewModel.swift
+//  EssentialFeediOS
+//
+//  Created by nicaho on 2024/8/20.
+//
+
+import Foundation
+import EssentialFeed
+
+final public class FeedViewModel {
+    private let feedLoader: FeedLoader
+    
+    public init(feedLoader: FeedLoader) {
+        self.feedLoader = feedLoader
+    }
+    
+    var onChange: ((FeedViewModel) -> Void)?
+    var onFeedLoad: (([FeedImage]) -> Void)?
+    
+    private(set) var isLoading: Bool = false {
+        didSet {
+            onChange?(self)
+        }
+    }
+    
+    func loadFeed() {
+        isLoading = true
+        feedLoader.load{ [weak self] result in
+            if let feed = try? result.get() {
+                self?.onFeedLoad?(feed)
+            }
+            self?.isLoading = false
+        }
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Views/UIView+Shimmering.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Views/UIView+Shimmering.swift
@@ -9,14 +9,25 @@ import UIKit
 
 extension UIView {
     public var isShimmering: Bool {
-        return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+//        return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+        set {
+            if newValue {
+                startShimmering()
+            } else {
+                stopShimmering()
+            }
+        }
+        
+        get {
+            return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+        }
     }
 
     private var shimmerAnimationKey: String {
         return "shimmer"
     }
 
-    func startShimmering() {
+    private func startShimmering() {
         let white = UIColor.white.cgColor
         let alpha = UIColor.white.withAlphaComponent(0.75).cgColor
         let width = bounds.width
@@ -38,7 +49,7 @@ extension UIView {
         gradient.add(animation, forKey: shimmerAnimationKey)
     }
 
-    func stopShimmering() {
+    private func stopShimmering() {
         layer.mask = nil
     }
 }

--- a/EssentialFeed/EssentialFeediOSTests/Feed UI/Controllers/FeedViewControllerTests.swift
+++ b/EssentialFeed/EssentialFeediOSTests/Feed UI/Controllers/FeedViewControllerTests.swift
@@ -255,7 +255,7 @@ final class FeedViewControllerTests: XCTestCase {
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
         let loader = LoaderSpy()
-        let sut = FeedUIComposor.feedComposedWith(feedLoader: loader, imageLoader: loader)
+        let sut = FeedUIComposer.feedComposedWith(feedLoader: loader, imageLoader: loader)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
     }

--- a/EssentialFeed/EssentialFeediOSTests/Helpers/FeedViewController+TestHelpers.swift
+++ b/EssentialFeed/EssentialFeediOSTests/Helpers/FeedViewController+TestHelpers.swift
@@ -20,7 +20,7 @@ extension FeedViewController {
         refreshControl = fake
         refreshController?.view = fake
     }
-    
+        
     func simulateAppearance() {
         if !isViewLoaded {
             loadViewIfNeeded()


### PR DESCRIPTION
MVVM: Reducing Boilerplate, Shifting Reusable Presentation Logic from Controllers into Cross-Platform (Stateful & Stateless) ViewModels, and Decoupling Presentation from UI Frameworks with Swift Generics

1.Moved model state management from UIKit View Controllers (UI layer) into cross-platform View Models (Presentation layer).
2.View Controllers now act as Binders between the View and the View Model.
3.The UI+Presentation composition happens within the FeedUIComposer.